### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 LacyLights Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
This PR adds the MIT License to the LacyLights frontend web interface.

## License Details
The MIT License allows:
- ✅ **Commercial use** - Companies can use the frontend in commercial lighting products
- ✅ **Open source use** - Free use, modification, and distribution of the React/Next.js interface
- ✅ **Attribution required** - Must include copyright notice and license text
- ✅ **No warranty** - Clear disclaimer of liability

## Frontend-Specific Benefits
- **UI component reuse** - Developers can extract and reuse lighting control components
- **Commercial integration** - Lighting companies can embed the interface in their products
- **Educational use** - Schools can use for teaching lighting control interfaces
- **Community contributions** - Encourages frontend developers to contribute improvements

The MIT License ensures proper credit while maximizing adoption of the LacyLights web interface.

🤖 Generated with [Claude Code](https://claude.ai/code)