### PR TITLE
Clean up TypeScript imports and unused variables in fixtures page

### DIFF
--- a/src/app/fixtures/page.tsx
+++ b/src/app/fixtures/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_PROJECT_FIXTURES, DELETE_FIXTURE_INSTANCE, CREATE_FIXTURE_INSTANCE } from '@/graphql/fixtures';
 import AddFixtureModal from '@/components/AddFixtureModal';
@@ -19,8 +19,8 @@ export default function FixturesPage() {
     skip: !currentProject?.id,
   });
 
-  const [deleteFixture, { loading: deleting }] = useMutation(DELETE_FIXTURE_INSTANCE, {
-    onCompleted: (data) => {
+  const [deleteFixture] = useMutation(DELETE_FIXTURE_INSTANCE, {
+    onCompleted: () => {
       // Even if the mutation returns null/undefined, refresh the list
       refetch();
     },


### PR DESCRIPTION
## Summary
Clean up TypeScript code in fixtures page by removing unused imports and variables.

- Remove unused `useEffect` import for better code cleanliness
- Remove unused `data` parameter from `onCompleted` callback (was not being used)
- Remove unused `deleting` loading state from mutation destructuring

## Test plan
- [ ] Verify fixtures page loads correctly
- [ ] Verify fixture deletion still works properly
- [ ] Verify TypeScript compilation succeeds
- [ ] Verify ESLint passes without warnings

These changes improve code quality and TypeScript strict mode compliance without changing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)