### PR TITLE
Update Node.js CI/CD versions to 22.x and 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: 'npm'
     
     - name: Install dependencies


### PR DESCRIPTION
## Summary
- Updated security audit job to use Node.js 24.x instead of 20.x
- Matrix builds were already updated to [22.x, 24.x] 
- Ensures all CI jobs use consistent, supported Node.js versions

## Changes
- `.github/workflows/ci.yml`: Updated single instance of Node.js 20.x → 24.x

## Rationale  
- Aligns with current LTS (22.x) and current release (24.x) standards
- Consistent with updates made to lacylights-node and lacylights-mcp repositories
- Ensures frontend CI runs against supported Node.js versions

## Test Plan
- [x] CI workflow validates successfully with new Node.js versions
- [x] No breaking changes expected - version update only

🤖 Generated with [Claude Code](https://claude.ai/code)