### PR TITLE
Replace polling with WebSocket subscription for current active scene

### DIFF
--- a/src/components/SceneEditorModal.tsx
+++ b/src/components/SceneEditorModal.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { GET_SCENE, UPDATE_SCENE, GET_CURRENT_ACTIVE_SCENE, START_PREVIEW_SESSION, CANCEL_PREVIEW_SESSION, UPDATE_PREVIEW_CHANNEL, INITIALIZE_PREVIEW_WITH_SCENE } from '@/graphql/scenes';
+import { useCurrentActiveScene } from '@/hooks/useCurrentActiveScene';
+import { GET_SCENE, UPDATE_SCENE, START_PREVIEW_SESSION, CANCEL_PREVIEW_SESSION, UPDATE_PREVIEW_CHANNEL, INITIALIZE_PREVIEW_WITH_SCENE } from '@/graphql/scenes';
 import { GET_PROJECT_FIXTURES, REORDER_SCENE_FIXTURES } from '@/graphql/fixtures';
 import {
   DndContext,
@@ -422,13 +423,11 @@ export default function SceneEditorModal({ isOpen, onClose, sceneId, onSceneUpda
     skip: !scene?.project?.id,
   });
 
-  // Query current active scene to check if this scene is currently being played
-  const { data: activeSceneData } = useQuery(GET_CURRENT_ACTIVE_SCENE, {
-    pollInterval: 1000, // Poll every 1 second for better live editing responsiveness
-  });
+  // Subscribe to current active scene updates to check if this scene is currently being played
+  const { currentActiveScene } = useCurrentActiveScene();
 
   // Check if the scene being edited is currently active
-  const isSceneCurrentlyActive = activeSceneData?.currentActiveScene?.id === sceneId;
+  const isSceneCurrentlyActive = currentActiveScene?.id === sceneId;
 
   const [updateScene, { loading: updating }] = useMutation(UPDATE_SCENE, {
     onCompleted: () => {

--- a/src/graphql/scenes.ts
+++ b/src/graphql/scenes.ts
@@ -248,6 +248,8 @@ export const DMX_OUTPUT_CHANGED = gql`
   }
 `;
 
+// Subscription for real-time updates when the currently active scene changes
+// Emits when a scene is activated/deactivated via scene activation or cue list playback
 export const CURRENT_ACTIVE_SCENE_UPDATED = gql`
   subscription CurrentActiveSceneUpdated {
     currentActiveSceneUpdated {

--- a/src/graphql/scenes.ts
+++ b/src/graphql/scenes.ts
@@ -249,7 +249,7 @@ export const DMX_OUTPUT_CHANGED = gql`
 `;
 
 // Subscription for real-time updates when the currently active scene changes
-// Emits when a scene is activated/deactivated via scene activation or cue list playback
+// Emits whenever the active scene changes, providing the updated scene information
 export const CURRENT_ACTIVE_SCENE_UPDATED = gql`
   subscription CurrentActiveSceneUpdated {
     currentActiveSceneUpdated {

--- a/src/graphql/scenes.ts
+++ b/src/graphql/scenes.ts
@@ -247,3 +247,11 @@ export const DMX_OUTPUT_CHANGED = gql`
     }
   }
 `;
+
+export const CURRENT_ACTIVE_SCENE_UPDATED = gql`
+  subscription CurrentActiveSceneUpdated {
+    currentActiveSceneUpdated {
+      id
+    }
+  }
+`;

--- a/src/hooks/useCurrentActiveScene.ts
+++ b/src/hooks/useCurrentActiveScene.ts
@@ -25,14 +25,23 @@ export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
     onData: ({ data: subscriptionData }) => {
       if (subscriptionData?.data?.currentActiveSceneUpdated) {
         const newActiveScene = subscriptionData.data.currentActiveSceneUpdated;
-        setCurrentActiveScene(newActiveScene);
+        // Only update state if the scene has actually changed to prevent unnecessary re-renders
+        setCurrentActiveScene(prevScene => {
+          if (newActiveScene?.id !== prevScene?.id) {
+            return newActiveScene;
+          }
+          return prevScene;
+        });
       }
     },
   });
 
-  // Set initial state from query data ONLY if we don't have subscription data yet
+  // Set initial state from query data or update if query returns different data
   useEffect(() => {
-    if (queryData?.currentActiveScene && !currentActiveScene) {
+    if (
+      queryData?.currentActiveScene &&
+      (!currentActiveScene || queryData.currentActiveScene.id !== currentActiveScene.id)
+    ) {
       setCurrentActiveScene(queryData.currentActiveScene);
     }
   }, [queryData, currentActiveScene]);

--- a/src/hooks/useCurrentActiveScene.ts
+++ b/src/hooks/useCurrentActiveScene.ts
@@ -21,7 +21,7 @@ export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
   });
 
   // Subscribe to real-time updates
-  const { loading: subscriptionLoading, error: subscriptionError } = useSubscription(CURRENT_ACTIVE_SCENE_UPDATED, {
+  const { error: subscriptionError } = useSubscription(CURRENT_ACTIVE_SCENE_UPDATED, {
     onData: ({ data: subscriptionData }) => {
       if (subscriptionData?.data?.currentActiveSceneUpdated) {
         const newActiveScene = subscriptionData.data.currentActiveSceneUpdated;
@@ -48,7 +48,7 @@ export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
 
   return {
     currentActiveScene,
-    isLoading: queryLoading || subscriptionLoading,
+    isLoading: queryLoading,
     error: (queryError || subscriptionError) as Error | undefined,
   };
 }

--- a/src/hooks/useCurrentActiveScene.ts
+++ b/src/hooks/useCurrentActiveScene.ts
@@ -1,0 +1,45 @@
+import { useQuery, useSubscription } from '@apollo/client';
+import { useState, useEffect } from 'react';
+import { GET_CURRENT_ACTIVE_SCENE, CURRENT_ACTIVE_SCENE_UPDATED } from '../graphql/scenes';
+
+interface CurrentActiveScene {
+  id: string;
+}
+
+interface UseCurrentActiveSceneResult {
+  currentActiveScene: CurrentActiveScene | null;
+  isLoading: boolean;
+  error?: Error;
+}
+
+export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
+  const [currentActiveScene, setCurrentActiveScene] = useState<CurrentActiveScene | null>(null);
+
+  // Query initial active scene
+  const { data: queryData, loading: queryLoading, error: queryError } = useQuery(GET_CURRENT_ACTIVE_SCENE, {
+    fetchPolicy: 'cache-and-network', // Always get fresh data on mount but use cache for immediate response
+  });
+
+  // Subscribe to real-time updates
+  const { loading: subscriptionLoading, error: subscriptionError } = useSubscription(CURRENT_ACTIVE_SCENE_UPDATED, {
+    onData: ({ data: subscriptionData }) => {
+      if (subscriptionData?.data?.currentActiveSceneUpdated) {
+        const newActiveScene = subscriptionData.data.currentActiveSceneUpdated;
+        setCurrentActiveScene(newActiveScene);
+      }
+    },
+  });
+
+  // Set initial state from query data ONLY if we don't have subscription data yet
+  useEffect(() => {
+    if (queryData?.currentActiveScene && !currentActiveScene) {
+      setCurrentActiveScene(queryData.currentActiveScene);
+    }
+  }, [queryData, currentActiveScene]);
+
+  return {
+    currentActiveScene,
+    isLoading: queryLoading || subscriptionLoading,
+    error: (queryError || subscriptionError) as Error | undefined,
+  };
+}

--- a/src/hooks/useCurrentActiveScene.ts
+++ b/src/hooks/useCurrentActiveScene.ts
@@ -44,7 +44,7 @@ export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
     ) {
       setCurrentActiveScene(queryData.currentActiveScene);
     }
-  }, [queryData, currentActiveScene]);
+  }, [queryData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     currentActiveScene,

--- a/src/hooks/useCurrentActiveScene.ts
+++ b/src/hooks/useCurrentActiveScene.ts
@@ -17,7 +17,7 @@ export function useCurrentActiveScene(): UseCurrentActiveSceneResult {
 
   // Query initial active scene
   const { data: queryData, loading: queryLoading, error: queryError } = useQuery(GET_CURRENT_ACTIVE_SCENE, {
-    fetchPolicy: 'cache-and-network', // Always get fresh data on mount but use cache for immediate response
+    fetchPolicy: 'cache-and-network', // Returns cached data if available and always makes a network request to update the data
   });
 
   // Subscribe to real-time updates


### PR DESCRIPTION
## Summary

Replaces inefficient 1-second polling with real-time WebSocket subscription for tracking the current active scene in SceneEditorModal.

## Changes

- **Added** `CURRENT_ACTIVE_SCENE_UPDATED` GraphQL subscription to `src/graphql/scenes.ts`
- **Created** `useCurrentActiveScene` hook following existing subscription patterns (`useCueListPlayback`)
- **Updated** `SceneEditorModal` to use subscription instead of `pollInterval: 1000`

## Benefits

- ✅ **Eliminates continuous polling**: No more HTTP requests every second
- ✅ **Real-time updates**: Instant notification when active scene changes  
- ✅ **Reduced backend load**: WebSocket connection vs constant HTTP requests
- ✅ **Better performance**: Removes unnecessary network traffic
- ✅ **Consistent patterns**: Follows established subscription architecture

## Technical Notes

- Implementation follows the same pattern as existing `useCueListPlayback` hook
- Uses initial query + subscription for optimal user experience
- Assumes backend support for `currentActiveSceneUpdated` subscription
- All lint and type checks pass

## Test Plan

- [ ] Verify scene editor shows correct active state when scenes are activated
- [ ] Confirm no more polling requests in network tab
- [ ] Test real-time updates when switching active scenes during cue list playback

🤖 Generated with [Claude Code](https://claude.ai/code)