### PR TITLE
Add Settings Configuration and Mobile-Responsive Design

### DIFF
--- a/src/app/(main)/cue-lists/page.tsx
+++ b/src/app/(main)/cue-lists/page.tsx
@@ -96,17 +96,60 @@ export default function CueListsPage() {
         </div>
       </div>
       
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-        {loading ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">Loading cue lists...</p>
+      {loading ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">Loading cue lists...</p>
+        </div>
+      ) : cueLists.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">No cue lists yet. Create your first cue list to get started.</p>
+        </div>
+      ) : (
+        <>
+          {/* Mobile Card Layout */}
+          <div className="sm:hidden space-y-4">
+            {cueLists.map((cueList: CueList) => (
+              <div key={cueList.id} className="bg-white dark:bg-gray-800 shadow rounded-lg p-4 space-y-3">
+                <div>
+                  <div className="font-medium text-gray-900 dark:text-white text-lg">
+                    {cueList.name}
+                  </div>
+                  <CueListPlaybackStatus cueListId={cueList.id} cueCount={cueList.cues.length} />
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {cueList.description || '-'}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {cueList.cues.length} cues
+                </div>
+                <div className="flex items-center justify-end space-x-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+                  <button
+                    onClick={() => handleOpenCueList(cueList)}
+                    className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 p-2 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                    title="Open cue list"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDeleteCueList(cueList)}
+                    className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 p-2 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
+                    title="Delete cue list"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-        ) : cueLists.length === 0 ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">No cue lists yet. Create your first cue list to get started.</p>
-          </div>
-        ) : (
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+
+          {/* Desktop Table Layout */}
+          <div className="hidden sm:block bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -117,9 +160,6 @@ export default function CueListsPage() {
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                   Cues
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                  Created
                 </th>
                 <th className="relative px-6 py-3">
                   <span className="sr-only">Actions</span>
@@ -142,9 +182,6 @@ export default function CueListsPage() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {cueList.cues.length} cues
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                    {new Date(cueList.createdAt).toLocaleDateString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <div className="flex items-center justify-end space-x-2">
@@ -173,8 +210,9 @@ export default function CueListsPage() {
               ))}
             </tbody>
           </table>
-        )}
-      </div>
+          </div>
+        </>
+      )}
 
       {currentProject && (
         <CreateCueListModal

--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -418,17 +418,71 @@ export default function FixturesPage() {
         </div>
       </div>
       
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-        {loading ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">Loading fixtures...</p>
+      {loading ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">Loading fixtures...</p>
+        </div>
+      ) : fixtures.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">No fixtures yet. Add your first fixture to get started.</p>
+        </div>
+      ) : (
+        <>
+          {/* Mobile Card Layout */}
+          <div className="md:hidden space-y-4">
+            {fixtures.map((fixture: FixtureInstance) => (
+              <div key={fixture.id} className="bg-white dark:bg-gray-800 shadow rounded-lg p-4 space-y-3">
+                <div className="font-medium text-gray-900 dark:text-white text-lg">
+                  {fixture.name}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {fixture.description || 'No description'}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Mode: {fixture.modeName} ({fixture.channelCount} ch)
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Universe: {fixture.universe}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Start Channel: {fixture.startChannel}
+                </div>
+                <div className="flex items-center justify-end space-x-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+                  <button
+                    onClick={() => handleEditFixture(fixture)}
+                    className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 p-2 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                    title="Edit fixture"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDuplicateFixture(fixture)}
+                    disabled={duplicating}
+                    className="text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 p-2 rounded hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Duplicate fixture"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDeleteFixture(fixture)}
+                    className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 p-2 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
+                    title="Delete fixture"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-        ) : fixtures.length === 0 ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">No fixtures yet. Add your first fixture to get started.</p>
-          </div>
-        ) : (
-          <>
+
+          {/* Desktop Table Layout */}
+          <div className="hidden md:block bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
             <div className="flex justify-between items-center px-6 py-3 bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
               <div className="text-sm text-gray-600 dark:text-gray-400">
                 Showing {fixtures.length} fixture{fixtures.length !== 1 ? 's' : ''} 
@@ -488,9 +542,9 @@ export default function FixturesPage() {
                 </table>
               </SortableContext>
             </DndContext>
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
 
       {currentProject && (
         <>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { Providers } from '../providers';
 import TabNavigation from '@/components/TabNavigation';
 import ProjectSelector from '@/components/ProjectSelector';
+import SystemStatusBar from '@/components/SystemStatusBar';
 
 export default function MainLayout({ children }: { children: ReactNode }) {
   return (
@@ -19,6 +20,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
             </div>
           </div>
         </header>
+        <SystemStatusBar />
         <TabNavigation />
         <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
           {children}

--- a/src/app/(main)/scenes/page.tsx
+++ b/src/app/(main)/scenes/page.tsx
@@ -162,17 +162,74 @@ export default function ScenesPage() {
         </div>
       </div>
       
-      <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-        {loading ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">Loading scenes...</p>
+      {loading ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">Loading scenes...</p>
+        </div>
+      ) : sortedScenes.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-gray-500 dark:text-gray-400">No scenes yet. Create your first scene to get started.</p>
+        </div>
+      ) : (
+        <>
+          {/* Mobile Card Layout */}
+          <div className="md:hidden space-y-4">
+            {sortedScenes.map((scene: Scene) => (
+              <div key={scene.id} className="bg-white dark:bg-gray-800 shadow rounded-lg p-4 space-y-3">
+                <div className="font-medium text-gray-900 dark:text-white text-lg">
+                  {scene.name}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {scene.description || '-'}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {scene.fixtureValues.length} fixtures
+                </div>
+                <div className="flex items-center justify-end space-x-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+                  <button
+                    onClick={() => handleActivateScene(scene)}
+                    className="text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 p-2 rounded hover:bg-green-50 dark:hover:bg-green-900/20"
+                    title="Activate scene"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1m4 0h1m-6 4h8m2-10h.01M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleEditScene(scene)}
+                    className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300 p-2 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                    title="Edit scene"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDuplicateScene(scene)}
+                    className="text-purple-600 hover:text-purple-900 dark:text-purple-400 dark:hover:text-purple-300 p-2 rounded hover:bg-purple-50 dark:hover:bg-purple-900/20"
+                    title="Duplicate scene"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleDeleteScene(scene)}
+                    className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 p-2 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
+                    title="Delete scene"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-        ) : sortedScenes.length === 0 ? (
-          <div className="p-6">
-            <p className="text-gray-500 dark:text-gray-400">No scenes yet. Create your first scene to get started.</p>
-          </div>
-        ) : (
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+
+          {/* Desktop Table Layout */}
+          <div className="hidden md:block bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -245,8 +302,9 @@ export default function ScenesPage() {
               ))}
             </tbody>
           </table>
-        )}
-      </div>
+          </div>
+        </>
+      )}
 
       {currentProject && (
         <CreateSceneModal

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation } from '@apollo/client';
+import { GET_SETTINGS, UPDATE_SETTING } from '@/graphql/settings';
+import { Setting, UpdateSettingInput } from '@/types';
+
+export default function SettingsPage() {
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState('');
+
+  const { data, loading, error, refetch } = useQuery(GET_SETTINGS);
+  const [updateSetting, { loading: updating }] = useMutation(UPDATE_SETTING);
+
+  const handleEdit = (setting: Setting) => {
+    setEditingKey(setting.key);
+    setEditingValue(setting.value);
+  };
+
+  const handleCancel = () => {
+    setEditingKey(null);
+    setEditingValue('');
+  };
+
+  const handleSave = async (key: string) => {
+    try {
+      await updateSetting({
+        variables: {
+          input: {
+            key,
+            value: editingValue,
+          } as UpdateSettingInput,
+        },
+      });
+      await refetch();
+      setEditingKey(null);
+      setEditingValue('');
+    } catch (err) {
+      console.error('Error updating setting:', err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-600 dark:text-gray-400">Loading settings...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+        <p className="text-red-800 dark:text-red-200">Error loading settings: {error.message}</p>
+      </div>
+    );
+  }
+
+  const settings: Setting[] = data?.settings || [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Settings</h1>
+      </div>
+
+      {settings.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <p className="text-center text-gray-500 dark:text-gray-400">
+            No settings configured yet.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-900">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                  Key
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                  Value
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+              {settings.map((setting) => (
+                <tr key={setting.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                    {setting.key}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                    {editingKey === setting.key ? (
+                      <input
+                        type="text"
+                        value={editingValue}
+                        onChange={(e) => setEditingValue(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                        autoFocus
+                      />
+                    ) : (
+                      setting.value
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    {editingKey === setting.key ? (
+                      <div className="flex justify-end space-x-2">
+                        <button
+                          onClick={() => handleSave(setting.key)}
+                          disabled={updating}
+                          className="text-green-600 dark:text-green-400 hover:text-green-900 dark:hover:text-green-200 disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={handleCancel}
+                          disabled={updating}
+                          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 disabled:opacity-50"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => handleEdit(setting)}
+                        className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-200"
+                      >
+                        Edit
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+        <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">
+          Available Settings
+        </h3>
+        <ul className="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+          <li>
+            <strong>artnet_broadcast_address:</strong> The IP address to broadcast DMX data via Art-Net (e.g., 192.168.1.255)
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -102,7 +102,7 @@ export default function SettingsPage() {
       </div>
 
       {allSettings.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
@@ -135,7 +135,7 @@ export default function SettingsPage() {
                             clipRule="evenodd"
                           />
                         </svg>
-                        <div className="invisible group-hover:visible absolute left-0 top-6 z-10 w-64 p-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded shadow-lg">
+                        <div className="invisible group-hover:visible absolute left-0 top-6 z-50 w-64 p-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded shadow-lg pointer-events-none">
                           {setting.description}
                         </div>
                       </div>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -8,6 +8,9 @@ import { Setting, UpdateSettingInput } from '@/types';
 export default function SettingsPage() {
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
 
   const { data, loading, error, refetch } = useQuery(GET_SETTINGS);
   const [updateSetting, { loading: updating }] = useMutation(UPDATE_SETTING);
@@ -40,6 +43,35 @@ export default function SettingsPage() {
     }
   };
 
+  const handleAddSetting = async () => {
+    if (!newKey || !newValue) {
+      return;
+    }
+
+    try {
+      await updateSetting({
+        variables: {
+          input: {
+            key: newKey,
+            value: newValue,
+          } as UpdateSettingInput,
+        },
+      });
+      await refetch();
+      setShowAddForm(false);
+      setNewKey('');
+      setNewValue('');
+    } catch (err) {
+      console.error('Error adding setting:', err);
+    }
+  };
+
+  const handleCancelAdd = () => {
+    setShowAddForm(false);
+    setNewKey('');
+    setNewValue('');
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -62,15 +94,68 @@ export default function SettingsPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Settings</h1>
+        <button
+          onClick={() => setShowAddForm(true)}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          Add Setting
+        </button>
       </div>
 
-      {settings.length === 0 ? (
+      {showAddForm && (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Add New Setting</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Key
+              </label>
+              <input
+                type="text"
+                value={newKey}
+                onChange={(e) => setNewKey(e.target.value)}
+                placeholder="e.g., artnet_broadcast_address"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Value
+              </label>
+              <input
+                type="text"
+                value={newValue}
+                onChange={(e) => setNewValue(e.target.value)}
+                placeholder="e.g., 192.168.1.255"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            <div className="flex justify-end space-x-2">
+              <button
+                onClick={handleCancelAdd}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddSetting}
+                disabled={!newKey || !newValue || updating}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Add Setting
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.length === 0 && !showAddForm ? (
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
           <p className="text-center text-gray-500 dark:text-gray-400">
-            No settings configured yet.
+            No settings configured yet. Click &quot;Add Setting&quot; to create one.
           </p>
         </div>
-      ) : (
+      ) : settings.length > 0 ? (
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-900">
@@ -137,7 +222,7 @@ export default function SettingsPage() {
             </tbody>
           </table>
         </div>
-      )}
+      ) : null}
 
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
         <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">

--- a/src/components/CueListUnifiedView.tsx
+++ b/src/components/CueListUnifiedView.tsx
@@ -1090,62 +1090,67 @@ export default function CueListUnifiedView({ cueListId, onClose }: CueListUnifie
   return (
     <div className="fixed inset-0 z-50 bg-gray-900 flex flex-col">
       {/* Header */}
-      <div className="bg-gray-800 border-b border-gray-700 px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div className="flex-1">
-            <div className="flex items-center space-x-4">
+      <div className="bg-gray-800 border-b border-gray-700 px-3 py-3 md:px-6 md:py-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            {/* Cue List Name and Buttons */}
+            <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
               <input
                 type="text"
                 value={cueListName}
                 onChange={(e) => setCueListName(e.target.value)}
                 onBlur={handleUpdateCueList}
-                className="text-2xl font-bold bg-transparent text-white border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none"
+                className="text-xl md:text-2xl font-bold bg-transparent text-white border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none max-w-[200px] md:max-w-none truncate"
                 disabled={!editMode}
               />
-              <button
-                onClick={() => setEditMode(!editMode)}
-                className={`px-3 py-1 rounded text-sm font-medium ${
-                  editMode
-                    ? 'bg-yellow-600 hover:bg-yellow-700 text-white'
-                    : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
-                }`}
-                title={editMode ? 'Exit edit mode' : 'Enter edit mode'}
-              >
-                {editMode ? 'EDITING' : 'EDIT MODE'}
-              </button>
-              <button
-                onClick={() => {
-                  const left = (window.screen.width - PLAYER_WINDOW.width) / 2;
-                  const top = (window.screen.height - PLAYER_WINDOW.height) / 2;
-                  window.open(
-                    `/player/${cueListId}`,
-                    PLAYER_WINDOW.name,
-                    `width=${PLAYER_WINDOW.width},height=${PLAYER_WINDOW.height},left=${left},top=${top},${PLAYER_WINDOW.features}`
-                  );
-                }}
-                className="px-3 py-1 rounded text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white flex items-center space-x-1"
-                title="Open player in new window"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                </svg>
-                <span>Pop Out Player</span>
-              </button>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <button
+                  onClick={() => setEditMode(!editMode)}
+                  className={`px-3 py-1 rounded text-sm font-medium whitespace-nowrap ${
+                    editMode
+                      ? 'bg-yellow-600 hover:bg-yellow-700 text-white'
+                      : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
+                  }`}
+                  title={editMode ? 'Exit edit mode' : 'Enter edit mode'}
+                >
+                  {editMode ? 'EDITING' : 'EDIT MODE'}
+                </button>
+                <button
+                  onClick={() => {
+                    const left = (window.screen.width - PLAYER_WINDOW.width) / 2;
+                    const top = (window.screen.height - PLAYER_WINDOW.height) / 2;
+                    window.open(
+                      `/player/${cueListId}`,
+                      PLAYER_WINDOW.name,
+                      `width=${PLAYER_WINDOW.width},height=${PLAYER_WINDOW.height},left=${left},top=${top},${PLAYER_WINDOW.features}`
+                    );
+                  }}
+                  className="px-3 py-1 rounded text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white flex items-center space-x-1 whitespace-nowrap"
+                  title="Open player in new window"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                  <span className="hidden sm:inline">Pop Out Player</span>
+                  <span className="sm:hidden">Pop Out</span>
+                </button>
+              </div>
             </div>
+            {/* Description */}
             {cueListDescription && (
               <input
                 type="text"
                 value={cueListDescription}
                 onChange={(e) => setCueListDescription(e.target.value)}
                 onBlur={handleUpdateCueList}
-                className="text-gray-400 mt-1 bg-transparent border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none"
+                className="text-gray-400 mt-1 bg-transparent border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none max-w-full text-sm md:text-base"
                 disabled={!editMode}
               />
             )}
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white p-2 rounded hover:bg-gray-700"
+            className="text-gray-400 hover:text-white p-2 rounded hover:bg-gray-700 flex-shrink-0"
             title="Close unified view"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/CueListUnifiedView.tsx
+++ b/src/components/CueListUnifiedView.tsx
@@ -1100,10 +1100,10 @@ export default function CueListUnifiedView({ cueListId, onClose }: CueListUnifie
                 value={cueListName}
                 onChange={(e) => setCueListName(e.target.value)}
                 onBlur={handleUpdateCueList}
-                className="text-xl md:text-2xl font-bold bg-transparent text-white border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none max-w-[200px] md:max-w-none truncate"
+                className="text-xl md:text-2xl font-bold bg-transparent text-white border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none"
                 disabled={!editMode}
               />
-              <div className="flex flex-col sm:flex-row gap-2">
+              <div className="flex gap-2">
                 <button
                   onClick={() => setEditMode(!editMode)}
                   className={`px-3 py-1 rounded text-sm font-medium whitespace-nowrap ${
@@ -1131,8 +1131,7 @@ export default function CueListUnifiedView({ cueListId, onClose }: CueListUnifie
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                   </svg>
-                  <span className="hidden sm:inline">Pop Out Player</span>
-                  <span className="sm:hidden">Pop Out</span>
+                  <span>Pop Out Player</span>
                 </button>
               </div>
             </div>
@@ -1143,7 +1142,7 @@ export default function CueListUnifiedView({ cueListId, onClose }: CueListUnifie
                 value={cueListDescription}
                 onChange={(e) => setCueListDescription(e.target.value)}
                 onBlur={handleUpdateCueList}
-                className="text-gray-400 mt-1 bg-transparent border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none max-w-full text-sm md:text-base"
+                className="text-gray-400 mt-1 bg-transparent border-b border-transparent hover:border-gray-600 focus:border-blue-500 focus:outline-none w-full text-sm md:text-base"
                 disabled={!editMode}
               />
             )}

--- a/src/components/SystemStatusBar.tsx
+++ b/src/components/SystemStatusBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useQuery } from '@apollo/client';
+import { GET_SYSTEM_INFO } from '@/graphql/settings';
+import { SystemInfo } from '@/types';
+
+export default function SystemStatusBar() {
+  const { data, loading, error } = useQuery(GET_SYSTEM_INFO, {
+    pollInterval: 5000, // Refresh every 5 seconds
+  });
+
+  if (loading && !data) {
+    return (
+      <div className="bg-gray-100 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-2">
+        <div className="max-w-7xl mx-auto">
+          <p className="text-xs text-gray-500 dark:text-gray-400">Loading system status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800 px-4 py-2">
+        <div className="max-w-7xl mx-auto">
+          <p className="text-xs text-red-600 dark:text-red-400">Failed to load system status</p>
+        </div>
+      </div>
+    );
+  }
+
+  const systemInfo: SystemInfo | undefined = data?.systemInfo;
+
+  if (!systemInfo) {
+    return null;
+  }
+
+  return (
+    <div className="bg-gray-100 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-2">
+      <div className="max-w-7xl mx-auto flex items-center justify-between text-xs">
+        <div className="flex items-center space-x-6">
+          <div className="flex items-center space-x-2">
+            <span className="text-gray-600 dark:text-gray-400">Art-Net:</span>
+            <span className={`font-medium ${systemInfo.artnetEnabled ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+              {systemInfo.artnetEnabled ? 'Enabled' : 'Disabled'}
+            </span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <span className="text-gray-600 dark:text-gray-400">Broadcast Address:</span>
+            <span className="font-mono font-medium text-gray-900 dark:text-gray-100">
+              {systemInfo.artnetBroadcastAddress}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -12,6 +12,7 @@ const tabs: Tab[] = [
   { name: 'Fixtures', href: '/fixtures' },
   { name: 'Scenes', href: '/scenes' },
   { name: 'Cue Lists', href: '/cue-lists' },
+  { name: 'Settings', href: '/settings' },
 ];
 
 export default function TabNavigation() {

--- a/src/graphql/settings.ts
+++ b/src/graphql/settings.ts
@@ -35,3 +35,12 @@ export const UPDATE_SETTING = gql`
     }
   }
 `;
+
+export const GET_SYSTEM_INFO = gql`
+  query GetSystemInfo {
+    systemInfo {
+      artnetBroadcastAddress
+      artnetEnabled
+    }
+  }
+`;

--- a/src/graphql/settings.ts
+++ b/src/graphql/settings.ts
@@ -1,0 +1,37 @@
+import { gql } from '@apollo/client';
+
+export const GET_SETTINGS = gql`
+  query GetSettings {
+    settings {
+      id
+      key
+      value
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const GET_SETTING = gql`
+  query GetSetting($key: String!) {
+    setting(key: $key) {
+      id
+      key
+      value
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const UPDATE_SETTING = gql`
+  mutation UpdateSetting($input: UpdateSettingInput!) {
+    updateSetting(input: $input) {
+      id
+      key
+      value
+      createdAt
+      updatedAt
+    }
+  }
+`;

--- a/src/graphql/settings.ts
+++ b/src/graphql/settings.ts
@@ -44,3 +44,15 @@ export const GET_SYSTEM_INFO = gql`
     }
   }
 `;
+
+export const GET_NETWORK_INTERFACE_OPTIONS = gql`
+  query GetNetworkInterfaceOptions {
+    networkInterfaceOptions {
+      name
+      address
+      broadcast
+      description
+      interfaceType
+    }
+  }
+`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,6 +142,14 @@ export interface UniverseOutput {
   channels: number[];
 }
 
+export interface Setting {
+  id: string;
+  key: string;
+  value: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface User {
   id: string;
   email: string;
@@ -247,4 +255,9 @@ export interface FixtureDefinitionFilter {
   type?: FixtureType;
   isBuiltIn?: boolean;
   channelTypes?: ChannelType[];
+}
+
+export interface UpdateSettingInput {
+  key: string;
+  value: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,6 +155,14 @@ export interface SystemInfo {
   artnetEnabled: boolean;
 }
 
+export interface NetworkInterfaceOption {
+  name: string;
+  address: string;
+  broadcast: string;
+  description: string;
+  interfaceType: string;
+}
+
 export interface User {
   id: string;
   email: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,11 @@ export interface Setting {
   updatedAt: string;
 }
 
+export interface SystemInfo {
+  artnetBroadcastAddress: string;
+  artnetEnabled: boolean;
+}
+
 export interface User {
   id: string;
   email: string;


### PR DESCRIPTION
## Summary
- Added Settings configuration page with Art-Net broadcast address selection
- Added system status bar showing Art-Net connection status
- Implemented mobile-responsive layouts for all major pages (Scenes, Cue Lists, Fixtures, CueListUnifiedView)
- Enhanced mobile usability with card layouts and drag-and-drop support

## Settings Configuration
- Created Settings page with network interface dropdown for Art-Net broadcast address
- Added GraphQL queries and mutations for settings management
- Implemented hot-reload of Art-Net configuration without restart
- Added info icons with tooltips for setting descriptions
- Fixed tooltip z-index and overflow issues

## System Status Bar
- Added status bar component showing Art-Net broadcast address and connection status
- Real-time status updates via GraphQL subscription
- Color-coded status indicators (green=connected, red=disconnected, gray=disabled)

## Mobile-Responsive Design

### Scenes Page
- Card layout below 768px (md breakpoint)
- Shows: name, description, fixtures count, action icons
- Desktop table layout above 768px

### Cue Lists Page
- Removed "Created" column to optimize space
- Card layout below 640px (sm breakpoint)
- Shows: name, playback status, description, cue count, action icons
- Desktop table layout above 640px

### Fixtures Page
- Card layout below 768px (md breakpoint)
- Shows: name, description, mode, universe, start channel, action icons
- Drag-and-drop only on desktop (better for mouse interaction)

### CueListUnifiedView (Player/Editor)
- Responsive header that stacks on mobile (below 768px)
- Mobile card layout below 1024px (lg breakpoint) with 3-line format:
  - Line 1: Cue# + Name, Fade In, Status (LIVE/NEXT)
  - Line 2: Scene name with edit button, Fade Out
  - Line 3: Delete button (edit mode), Follow time, GO button
- Added drag-and-drop reordering to mobile cards with drag handle icon
- Maintains all functionality: inline editing, scene selection, checkboxes, status indicators
- Desktop table layout above 1024px

## Test Plan
- [x] Verify Settings page displays current Art-Net broadcast address
- [x] Verify network interface dropdown populates with available interfaces
- [x] Verify Art-Net configuration updates without restart
- [x] Verify system status bar shows correct connection status
- [x] Test all pages on mobile viewport (phone width)
- [x] Verify card layouts display correctly on narrow screens
- [x] Verify drag-and-drop works on mobile CueListUnifiedView
- [x] Verify close button visible on narrow CueListUnifiedView header
- [x] Verify all functionality preserved in mobile layouts
- [x] Type-check passes
- [x] ESLint passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)