### PR TITLE
docs(eos): document Eos ASCII import/export UI in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,9 @@ render(
 - UI: `ImportExportButtons.tsx` exposes "ETC Eos (.asc)" alongside QLC+
   and native JSON
 - Auto-detection by file extension; explicit format selection in the dropdown
-- Warnings rendered via `EosImportWarningsList.tsx`, grouped by warning code
+- Warnings rendered via `EosWarningsList` (`src/components/EosWarningsList.tsx`),
+  grouped by warning code
 - Backend mutations: `IMPORT_PROJECT_FROM_EOS`, `EXPORT_PROJECT_TO_EOS`
   (`src/graphql/projects.ts`)
-- Downloaded filename uses the backend's `filenameSuffix` field
+- Downloaded Eos export filenames currently use a frontend-hardcoded `.asc`
+  suffix rather than the backend's `filenameSuffix` field

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,12 @@ render(
 - Timeline-based cue management
 - Fade time editing
 - Playback controls
+
+### Import/Export (Eos ASCII)
+- UI: `ImportExportButtons.tsx` exposes "ETC Eos (.asc)" alongside QLC+
+  and native JSON
+- Auto-detection by file extension; explicit format selection in the dropdown
+- Warnings rendered via `EosImportWarningsList.tsx`, grouped by warning code
+- Backend mutations: `IMPORT_PROJECT_FROM_EOS`, `EXPORT_PROJECT_TO_EOS`
+  (`src/graphql/projects.ts`)
+- Downloaded filename uses the backend's `filenameSuffix` field


### PR DESCRIPTION
## Summary

Phase 5, Task 34 of the Eos ASCII importer/exporter implementation plan
(\`lacylights/docs/plans/2026-04-28-eos-ascii-importer-exporter-implementation.md\`).

Adds an \"Import/Export (Eos ASCII)\" subsection to CLAUDE.md under Key Components. Documents:

- \`ImportExportButtons.tsx\` and the new dropdown entry
- auto-detection by file extension
- \`EosImportWarningsList.tsx\` warnings panel (grouped by warning code)
- backend GraphQL operations in \`src/graphql/projects.ts\`
- \`filenameSuffix\` field used for the downloaded filename

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)