### PR TITLE
feat(fixtures): add manufacturer / model / mode column to Fixtures list

### DIFF
--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -114,10 +114,13 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
           {fixture.name}
         </div>
       </td>
-      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+      <td className="px-6 py-4 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
         <div className="break-words whitespace-normal">
           <div>{fixture.manufacturer || '—'}</div>
           <div>{fixture.model || '—'}</div>
+          {fixture.modeName && fixture.modeName !== 'default' && (
+            <div>{fixture.modeName}</div>
+          )}
         </div>
       </td>
       <td className="px-6 py-4 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
@@ -126,7 +129,7 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
         </div>
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-        {fixture.modeName} ({fixture.channelCount} ch)
+        {fixture.channelCount} ch
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
         {fixture.universe}
@@ -468,12 +471,15 @@ export default function FixturesPage() {
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   {fixture.manufacturer || '—'} / {fixture.model || '—'}
+                  {fixture.modeName && fixture.modeName !== 'default' && (
+                    <> / {fixture.modeName}</>
+                  )}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   {fixture.description || 'No description'}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Mode: {fixture.modeName} ({fixture.channelCount} ch)
+                  Channels: {fixture.channelCount}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   Universe: {fixture.universe}
@@ -550,7 +556,7 @@ export default function FixturesPage() {
                         Description
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Mode
+                        Channels
                       </th>
                       <SortableHeader field="universe" currentField={sortField} currentDirection={sortDirection} onSort={handleSort}>
                         Universe

--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -114,6 +114,12 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
           {fixture.name}
         </div>
       </td>
+      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+        <div className="break-words whitespace-normal">
+          <div>{fixture.manufacturer || '—'}</div>
+          <div>{fixture.model || '—'}</div>
+        </div>
+      </td>
       <td className="px-6 py-4 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
         <div className="break-words whitespace-normal">
           {fixture.description || 'No description'}
@@ -461,6 +467,9 @@ export default function FixturesPage() {
                   {fixture.name}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {fixture.manufacturer || '—'} / {fixture.model || '—'}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
                   {fixture.description || 'No description'}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
@@ -534,6 +543,9 @@ export default function FixturesPage() {
                       <SortableHeader field="name" currentField={sortField} currentDirection={sortDirection} onSort={handleSort}>
                         Name
                       </SortableHeader>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Manufacturer / Model
+                      </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Description
                       </th>

--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -117,8 +117,14 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
       </td>
       <td className="px-6 py-4 text-xs text-gray-500 dark:text-gray-400 max-w-xs">
         <div className="break-words whitespace-normal">
-          <div>{fixture.manufacturer || '—'}</div>
-          <div>{fixture.model || '—'}</div>
+          {fixture.manufacturer || fixture.model ? (
+            <>
+              <div>{fixture.manufacturer || '—'}</div>
+              <div>{fixture.model || '—'}</div>
+            </>
+          ) : (
+            <div>—</div>
+          )}
           {shouldDisplayModeName(fixture.modeName) && (
             <div>{fixture.modeName}</div>
           )}
@@ -470,11 +476,16 @@ export default function FixturesPage() {
                 <div className="font-medium text-gray-900 dark:text-white text-lg">
                   {fixture.name}
                 </div>
-                {(fixture.manufacturer || fixture.model) && (
+                {(fixture.manufacturer || fixture.model || shouldDisplayModeName(fixture.modeName)) && (
                   <div className="text-sm text-gray-500 dark:text-gray-400">
-                    {fixture.manufacturer || '—'} / {fixture.model || '—'}
+                    {(fixture.manufacturer || fixture.model) && (
+                      <>{fixture.manufacturer || '—'} / {fixture.model || '—'}</>
+                    )}
                     {shouldDisplayModeName(fixture.modeName) && (
-                      <> / {fixture.modeName}</>
+                      <>
+                        {(fixture.manufacturer || fixture.model) ? ' / ' : ''}
+                        {fixture.modeName}
+                      </>
                     )}
                   </div>
                 )}

--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_PROJECT_FIXTURES, DELETE_FIXTURE_INSTANCE, REORDER_PROJECT_FIXTURES } from '@/graphql/fixtures';
-import { DEFAULT_MODE_NAME } from '@/constants/fixtures';
+import { shouldDisplayModeName } from '@/constants/fixtures';
 import { useRouter } from 'next/navigation';
 import AddFixtureModal from '@/components/AddFixtureModal';
 import EditFixtureModal from '@/components/EditFixtureModal';
@@ -119,7 +119,7 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
         <div className="break-words whitespace-normal">
           <div>{fixture.manufacturer || '—'}</div>
           <div>{fixture.model || '—'}</div>
-          {fixture.modeName && fixture.modeName !== DEFAULT_MODE_NAME && (
+          {shouldDisplayModeName(fixture.modeName) && (
             <div>{fixture.modeName}</div>
           )}
         </div>
@@ -473,7 +473,7 @@ export default function FixturesPage() {
                 {(fixture.manufacturer || fixture.model) && (
                   <div className="text-sm text-gray-500 dark:text-gray-400">
                     {fixture.manufacturer || '—'} / {fixture.model || '—'}
-                    {fixture.modeName && fixture.modeName !== DEFAULT_MODE_NAME && (
+                    {shouldDisplayModeName(fixture.modeName) && (
                       <> / {fixture.modeName}</>
                     )}
                   </div>

--- a/src/app/(main)/fixtures/page.tsx
+++ b/src/app/(main)/fixtures/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_PROJECT_FIXTURES, DELETE_FIXTURE_INSTANCE, REORDER_PROJECT_FIXTURES } from '@/graphql/fixtures';
+import { DEFAULT_MODE_NAME } from '@/constants/fixtures';
 import { useRouter } from 'next/navigation';
 import AddFixtureModal from '@/components/AddFixtureModal';
 import EditFixtureModal from '@/components/EditFixtureModal';
@@ -118,7 +119,7 @@ function SortableRow({ fixture, onEdit, onDuplicate, onDelete }: SortableRowProp
         <div className="break-words whitespace-normal">
           <div>{fixture.manufacturer || '—'}</div>
           <div>{fixture.model || '—'}</div>
-          {fixture.modeName && fixture.modeName !== 'default' && (
+          {fixture.modeName && fixture.modeName !== DEFAULT_MODE_NAME && (
             <div>{fixture.modeName}</div>
           )}
         </div>
@@ -469,17 +470,19 @@ export default function FixturesPage() {
                 <div className="font-medium text-gray-900 dark:text-white text-lg">
                   {fixture.name}
                 </div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  {fixture.manufacturer || '—'} / {fixture.model || '—'}
-                  {fixture.modeName && fixture.modeName !== 'default' && (
-                    <> / {fixture.modeName}</>
-                  )}
-                </div>
+                {(fixture.manufacturer || fixture.model) && (
+                  <div className="text-sm text-gray-500 dark:text-gray-400">
+                    {fixture.manufacturer || '—'} / {fixture.model || '—'}
+                    {fixture.modeName && fixture.modeName !== DEFAULT_MODE_NAME && (
+                      <> / {fixture.modeName}</>
+                    )}
+                  </div>
+                )}
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   {fixture.description || 'No description'}
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Channels: {fixture.channelCount}
+                  {fixture.channelCount} ch
                 </div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   Universe: {fixture.universe}

--- a/src/constants/__tests__/fixtures.test.ts
+++ b/src/constants/__tests__/fixtures.test.ts
@@ -5,6 +5,7 @@ import {
   getFixtureKey,
   getManufacturer,
   getModel,
+  shouldDisplayModeName,
 } from '../fixtures';
 
 describe('fixtures constants', () => {
@@ -83,6 +84,32 @@ describe('fixtures constants', () => {
 
     it('should return fallback for undefined', () => {
       expect(getModel(undefined)).toBe(UNKNOWN_MODEL);
+    });
+  });
+
+  describe('shouldDisplayModeName', () => {
+    it('should display a real mode name', () => {
+      expect(shouldDisplayModeName('16-channel')).toBe(true);
+      expect(shouldDisplayModeName('Mode A')).toBe(true);
+    });
+
+    it('should hide the implicit default sentinel', () => {
+      expect(shouldDisplayModeName('default')).toBe(false);
+      expect(shouldDisplayModeName(DEFAULT_MODE_NAME)).toBe(false);
+    });
+
+    it('should hide null, undefined, and empty mode names', () => {
+      expect(shouldDisplayModeName(null)).toBe(false);
+      expect(shouldDisplayModeName(undefined)).toBe(false);
+      expect(shouldDisplayModeName('')).toBe(false);
+    });
+
+    it('should be case-sensitive (only the exact sentinel is suppressed)', () => {
+      // The backend sentinel is the lowercase string "default"; a mode that
+      // happens to be named "Default" with different casing should still be
+      // shown to the user — it is a real mode, not the implicit one.
+      expect(shouldDisplayModeName('Default')).toBe(true);
+      expect(shouldDisplayModeName('DEFAULT')).toBe(true);
     });
   });
 });

--- a/src/constants/__tests__/fixtures.test.ts
+++ b/src/constants/__tests__/fixtures.test.ts
@@ -1,6 +1,7 @@
 import {
   UNKNOWN_MANUFACTURER,
   UNKNOWN_MODEL,
+  DEFAULT_MODE_NAME,
   getFixtureKey,
   getManufacturer,
   getModel,
@@ -16,6 +17,12 @@ describe('fixtures constants', () => {
   describe('UNKNOWN_MODEL', () => {
     it('should have the correct fallback value', () => {
       expect(UNKNOWN_MODEL).toBe('unknown');
+    });
+  });
+
+  describe('DEFAULT_MODE_NAME', () => {
+    it('should match the backend sentinel for the implicit default mode', () => {
+      expect(DEFAULT_MODE_NAME).toBe('default');
     });
   });
 

--- a/src/constants/fixtures.ts
+++ b/src/constants/fixtures.ts
@@ -9,6 +9,13 @@ export const UNKNOWN_MANUFACTURER = 'unknown';
 export const UNKNOWN_MODEL = 'unknown';
 
 /**
+ * Sentinel value used by the backend for the implicit default mode of a
+ * fixture. This is treated as "no real mode" by the UI and is hidden from
+ * mode-display affordances so users don't see a redundant "default" label.
+ */
+export const DEFAULT_MODE_NAME = 'default';
+
+/**
  * Generate a fixture key for mapping purposes
  * @param manufacturer - Fixture manufacturer (nullable)
  * @param model - Fixture model (nullable)

--- a/src/constants/fixtures.ts
+++ b/src/constants/fixtures.ts
@@ -45,3 +45,20 @@ export function getManufacturer(manufacturer: string | null | undefined): string
 export function getModel(model: string | null | undefined): string {
   return model ?? UNKNOWN_MODEL;
 }
+
+/**
+ * Returns true when a fixture's `modeName` is meaningful enough to display
+ * to the user. This is the UI guard used by the Fixtures list to decide
+ * whether to render the mode row in the Manufacturer / Model cell and the
+ * mobile card: empty / nullish values are hidden, and the backend's
+ * implicit-default sentinel ({@link DEFAULT_MODE_NAME}) is also hidden so
+ * simple fixtures don't show a redundant "default" label.
+ *
+ * Centralised here so both desktop and mobile layouts stay in sync if the
+ * sentinel ever changes, and so the behaviour is easy to unit-test.
+ */
+export function shouldDisplayModeName(
+  modeName: string | null | undefined
+): modeName is string {
+  return Boolean(modeName) && modeName !== DEFAULT_MODE_NAME;
+}


### PR DESCRIPTION
## Summary
- New "Manufacturer / Model" column on `/fixtures`, rendered as stacked rows so it stays compact alongside the wrappable Description column. Adds an optional third row for `modeName` when the fixture has a real mode (skipped when the API returns the implicit `"default"`).
- The previous "Mode" column has been replaced with a "Channels" column showing just the channel count, since mode now lives in the mfr/model cell.
- Mobile card view mirrors the same information density.
- Cell typography matches the Description column (`text-xs`).

## Notes
- Pairs with [bbernstein/lacylights-go#TBD](https://github.com/bbernstein/lacylights-go/pulls), which fixes a backend bug where Eos-imported fixtures had empty manufacturer/model values. Without that PR, Eos-imported fixtures display as `—`.

## Test plan
- [x] `npm run check` (type-check + lint)
- [x] `npm test` — 2763 passing
- [ ] Manual: load `/fixtures` and verify column rendering, sort order, mobile view
- [ ] Manual: confirm fixtures without modes show only mfr/model (no "default" line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)