### PR TITLE
fix(BottomSheet): don't close modal when text-selection drag ends on backdrop

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -229,8 +229,12 @@ export default function BottomSheet({
   // Close on a backdrop click only when the press started on the backdrop.
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      // Read then clear unconditionally: every click ends a press, so the flag must
+      // not survive into the next interaction even when this click does not dismiss.
       const startedInside = pressStartedInsideRef.current;
       pressStartedInsideRef.current = false;
+      // The e.target === e.currentTarget guard is kept deliberately: it also rejects
+      // synthetic clicks that bypass the pointer flow, so it is not redundant.
       if (e.target === e.currentTarget && closeOnBackdrop && !startedInside) {
         onClose();
       }

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -127,10 +127,8 @@ export default function BottomSheet({
   const dragCurrentY = useRef<number | null>(null);
   const isDragging = useRef(false);
   const canSwipe = useRef(false); // Only true when touch starts on handle
-  // True when the most recent press began on a modal child rather than the
-  // backdrop itself. The browser dispatches `click` to the common ancestor of
-  // the press/release targets, so a press inside the modal (e.g. selecting text)
-  // that releases on the backdrop must not be treated as a backdrop dismissal.
+  // `click` fires on the common ancestor of the press/release targets, so track
+  // press origin: a drag out from modal content must not count as a backdrop dismissal.
   const pressStartedInsideRef = useRef(false);
 
   // Handle escape key to close and Tab key for focus trapping

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -204,10 +204,27 @@ export default function BottomSheet({
     }
   }, [isOpen]);
 
+  // Tracks whether the most recent press started inside the modal content
+  // rather than on the backdrop itself.
+  const pressStartedInsideRef = useRef(false);
+
+  // Record where the press began. The browser dispatches `click` to the common
+  // ancestor of the mousedown and mouseup targets, so a press that starts inside
+  // the modal (e.g. selecting text in a field) and releases on the backdrop would
+  // otherwise be reported as a backdrop click and wrongly close the modal.
+  const handleBackdropMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      pressStartedInsideRef.current = e.target !== e.currentTarget;
+    },
+    []
+  );
+
   // Handle backdrop click to close
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget && closeOnBackdrop) {
+      const startedInside = pressStartedInsideRef.current;
+      pressStartedInsideRef.current = false;
+      if (e.target === e.currentTarget && closeOnBackdrop && !startedInside) {
         onClose();
       }
     },
@@ -295,6 +312,7 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 z-50"
+        onMouseDown={handleBackdropMouseDown}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -372,6 +390,7 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+        onMouseDown={handleBackdropMouseDown}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -209,7 +209,10 @@ export default function BottomSheet({
     }
   }, [isOpen]);
 
-  // Pointer events cover mouse, touch, and pen, and fire before `click`.
+  // Registered on the backdrop in the capture phase so it fires before the event
+  // reaches any child: arbitrary `children` (sliders, color pickers, etc.) may call
+  // stopPropagation() on pointer events, which would otherwise prevent us from
+  // recording the press origin. Pointer events also cover mouse, touch, and pen.
   const handleBackdropPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       pressStartedInsideRef.current = e.target !== e.currentTarget;
@@ -316,8 +319,8 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 z-50"
-        onPointerDown={handleBackdropPointerDown}
-        onPointerCancel={handleBackdropPointerCancel}
+        onPointerDownCapture={handleBackdropPointerDown}
+        onPointerCancelCapture={handleBackdropPointerCancel}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -327,8 +330,6 @@ export default function BottomSheet({
                      rounded-t-2xl shadow-xl transform transition-transform duration-300 ease-out
                      ${fullHeightMobile ? 'top-4' : 'max-h-[90vh]'}
                      flex flex-col animate-slide-up`}
-          // NOTE: do not add onPointerDown stopPropagation here — handleBackdropPointerDown
-          // relies on bubbled pointerdown to tell an inside-press-then-drag from a backdrop press.
           onClick={(e) => e.stopPropagation()}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
@@ -397,8 +398,8 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-        onPointerDown={handleBackdropPointerDown}
-        onPointerCancel={handleBackdropPointerCancel}
+        onPointerDownCapture={handleBackdropPointerDown}
+        onPointerCancelCapture={handleBackdropPointerCancel}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -406,8 +407,6 @@ export default function BottomSheet({
           ref={sheetRef}
           className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl ${maxWidth} w-full mx-4
                      max-h-[90vh] flex flex-col animate-fade-in`}
-          // NOTE: do not add onPointerDown stopPropagation here — handleBackdropPointerDown
-          // relies on bubbled pointerdown to tell an inside-press-then-drag from a backdrop press.
           onClick={(e) => e.stopPropagation()}
           role="dialog"
           aria-modal="true"

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -127,6 +127,11 @@ export default function BottomSheet({
   const dragCurrentY = useRef<number | null>(null);
   const isDragging = useRef(false);
   const canSwipe = useRef(false); // Only true when touch starts on handle
+  // True when the most recent press began on a modal child rather than the
+  // backdrop itself. The browser dispatches `click` to the common ancestor of
+  // the press/release targets, so a press inside the modal (e.g. selecting text)
+  // that releases on the backdrop must not be treated as a backdrop dismissal.
+  const pressStartedInsideRef = useRef(false);
 
   // Handle escape key to close and Tab key for focus trapping
   const handleKeyDown = useCallback(
@@ -197,29 +202,24 @@ export default function BottomSheet({
     };
   }, [isOpen, handleKeyDown]);
 
-  // Reset initial focus ref when modal closes
+  // Reset transient refs when modal closes so stale state can't leak into the
+  // next open (e.g. a press-inside followed by Escape, then a later backdrop click)
   useEffect(() => {
     if (!isOpen) {
       didInitialFocusRef.current = false;
+      pressStartedInsideRef.current = false;
     }
   }, [isOpen]);
 
-  // Tracks whether the most recent press started inside the modal content
-  // rather than on the backdrop itself.
-  const pressStartedInsideRef = useRef(false);
-
-  // Record where the press began. The browser dispatches `click` to the common
-  // ancestor of the mousedown and mouseup targets, so a press that starts inside
-  // the modal (e.g. selecting text in a field) and releases on the backdrop would
-  // otherwise be reported as a backdrop click and wrongly close the modal.
-  const handleBackdropMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+  // Pointer events cover mouse, touch, and pen, and fire before `click`.
+  const handleBackdropPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
       pressStartedInsideRef.current = e.target !== e.currentTarget;
     },
     []
   );
 
-  // Handle backdrop click to close
+  // Close on a backdrop click only when the press started on the backdrop.
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const startedInside = pressStartedInsideRef.current;
@@ -312,7 +312,7 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 z-50"
-        onMouseDown={handleBackdropMouseDown}
+        onPointerDown={handleBackdropPointerDown}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -390,7 +390,7 @@ export default function BottomSheet({
     sheetContent = (
       <div
         className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-        onMouseDown={handleBackdropMouseDown}
+        onPointerDown={handleBackdropPointerDown}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -217,6 +217,12 @@ export default function BottomSheet({
     []
   );
 
+  // A cancelled gesture (e.g. OS-interrupted touch) fires no `click`, so clear the
+  // flag here to avoid a stale "started inside" leaking into the next interaction.
+  const handleBackdropPointerCancel = useCallback(() => {
+    pressStartedInsideRef.current = false;
+  }, []);
+
   // Close on a backdrop click only when the press started on the backdrop.
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -311,6 +317,7 @@ export default function BottomSheet({
       <div
         className="fixed inset-0 bg-black bg-opacity-50 z-50"
         onPointerDown={handleBackdropPointerDown}
+        onPointerCancel={handleBackdropPointerCancel}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -320,6 +327,8 @@ export default function BottomSheet({
                      rounded-t-2xl shadow-xl transform transition-transform duration-300 ease-out
                      ${fullHeightMobile ? 'top-4' : 'max-h-[90vh]'}
                      flex flex-col animate-slide-up`}
+          // NOTE: do not add onPointerDown stopPropagation here — handleBackdropPointerDown
+          // relies on bubbled pointerdown to tell an inside-press-then-drag from a backdrop press.
           onClick={(e) => e.stopPropagation()}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
@@ -389,6 +398,7 @@ export default function BottomSheet({
       <div
         className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
         onPointerDown={handleBackdropPointerDown}
+        onPointerCancel={handleBackdropPointerCancel}
         onClick={handleBackdropClick}
         data-testid={`${testId}-backdrop`}
       >
@@ -396,6 +406,8 @@ export default function BottomSheet({
           ref={sheetRef}
           className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl ${maxWidth} w-full mx-4
                      max-h-[90vh] flex flex-col animate-fade-in`}
+          // NOTE: do not add onPointerDown stopPropagation here — handleBackdropPointerDown
+          // relies on bubbled pointerdown to tell an inside-press-then-drag from a backdrop press.
           onClick={(e) => e.stopPropagation()}
           role="dialog"
           aria-modal="true"

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -61,7 +61,9 @@ describe('BottomSheet', () => {
       const onClose = jest.fn();
       render(<BottomSheet {...defaultProps} onClose={onClose} />);
 
-      fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(backdrop);
+      fireEvent.click(backdrop);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
@@ -171,6 +173,28 @@ describe('BottomSheet', () => {
       render(<BottomSheet {...defaultProps} title="Mobile Sheet" />);
       expect(screen.getByTestId('bottom-sheet')).toBeInTheDocument();
       expect(screen.getByText('Mobile Sheet')).toBeInTheDocument();
+    });
+
+    it('does not call onClose when the press starts inside the sheet and releases on the backdrop', () => {
+      const onClose = jest.fn();
+      render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(screen.getByTestId('content'));
+      fireEvent.pointerUp(backdrop);
+      fireEvent.click(backdrop);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when the press starts and releases on the backdrop', () => {
+      const onClose = jest.fn();
+      render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(backdrop);
+      fireEvent.pointerUp(backdrop);
+      fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it('shows drag handle by default on mobile', () => {

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -200,6 +200,20 @@ describe('BottomSheet', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('clears press-started-inside state when closed so a later backdrop click still closes', () => {
+      const onClose = jest.fn();
+      const { rerender } = render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      fireEvent.pointerDown(screen.getByTestId('content'));
+      rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen={false} />);
+      rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen />);
+
+      // No backdrop pointerDown: the close-effect cleanup must be the only thing
+      // that cleared the stale ref (mirrors the desktop regression test).
+      fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('shows drag handle by default on mobile', () => {
       render(<BottomSheet {...defaultProps} />);
       // The drag handle is a div with specific styling (w-10 h-1)
@@ -229,6 +243,22 @@ describe('BottomSheet', () => {
       render(<BottomSheet {...defaultProps} fullHeightMobile />);
       const sheet = screen.getByTestId('bottom-sheet');
       expect(sheet).toHaveClass('top-4');
+    });
+  });
+
+  describe('Pointer cancellation', () => {
+    it('does not block a later backdrop dismissal after a cancelled inside press', () => {
+      // An OS-interrupted gesture fires pointercancel (no click). The ref must be
+      // cleared so a subsequent direct backdrop click still dismisses the modal.
+      const onClose = jest.fn();
+      render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(screen.getByTestId('content'));
+      fireEvent.pointerCancel(backdrop);
+
+      fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -250,15 +250,40 @@ describe('BottomSheet', () => {
     it('does not block a later backdrop dismissal after a cancelled inside press', () => {
       // An OS-interrupted gesture fires pointercancel (no click). The ref must be
       // cleared so a subsequent direct backdrop click still dismisses the modal.
+      // pointercancel is dispatched to the element that got the pointerdown (the
+      // content) and propagates from there, as in a real browser.
       const onClose = jest.fn();
       render(<BottomSheet {...defaultProps} onClose={onClose} />);
 
       const backdrop = screen.getByTestId('bottom-sheet-backdrop');
-      fireEvent.pointerDown(screen.getByTestId('content'));
-      fireEvent.pointerCancel(backdrop);
+      const content = screen.getByTestId('content');
+      fireEvent.pointerDown(content);
+      fireEvent.pointerCancel(content);
 
       fireEvent.click(backdrop);
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Press-origin tracking resilience', () => {
+    it('tracks an inside press even when a child stops pointer-event propagation', () => {
+      // The backdrop uses capture-phase pointer handlers, so a child calling
+      // stopPropagation() (e.g. a slider/color picker) cannot prevent press-origin
+      // tracking. The bubble-phase approach would regress here.
+      const onClose = jest.fn();
+      render(
+        <BottomSheet {...defaultProps} onClose={onClose}>
+          <button data-testid="grabby" onPointerDown={(e) => e.stopPropagation()}>
+            grab
+          </button>
+        </BottomSheet>
+      );
+
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(screen.getByTestId('grabby'));
+      fireEvent.pointerUp(backdrop);
+      fireEvent.click(backdrop);
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -73,6 +73,28 @@ describe('BottomSheet', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
+    it('does not call onClose when the press starts inside the modal and releases on the backdrop', () => {
+      // Repro: selecting text in a field, dragging the mouse off the modal, and
+      // releasing. The browser dispatches the resulting click to the common
+      // ancestor of mousedown/mouseup (the backdrop), which must NOT close it.
+      const onClose = jest.fn();
+      render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      fireEvent.mouseDown(screen.getByTestId('content'));
+      fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when the press starts and releases on the backdrop', () => {
+      const onClose = jest.fn();
+      render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.mouseDown(backdrop);
+      fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('calls onClose when Escape is pressed', () => {
       const onClose = jest.fn();
       render(<BottomSheet {...defaultProps} onClose={onClose} />);

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -110,6 +110,9 @@ describe('BottomSheet', () => {
       rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen={false} />);
       rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen />);
 
+      // Intentionally NO pointerDown on the backdrop here: the close-effect cleanup
+      // must be the only thing that cleared the stale ref. Firing a backdrop
+      // pointerDown would reset it independently and mask a cleanup regression.
       fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
       expect(onClose).toHaveBeenCalledTimes(1);
     });

--- a/src/components/__tests__/BottomSheet.test.tsx
+++ b/src/components/__tests__/BottomSheet.test.tsx
@@ -74,14 +74,16 @@ describe('BottomSheet', () => {
     });
 
     it('does not call onClose when the press starts inside the modal and releases on the backdrop', () => {
-      // Repro: selecting text in a field, dragging the mouse off the modal, and
+      // Repro: selecting text in a field, dragging the pointer off the modal, and
       // releasing. The browser dispatches the resulting click to the common
-      // ancestor of mousedown/mouseup (the backdrop), which must NOT close it.
+      // ancestor of the press/release targets (the backdrop), which must NOT close it.
       const onClose = jest.fn();
       render(<BottomSheet {...defaultProps} onClose={onClose} />);
 
-      fireEvent.mouseDown(screen.getByTestId('content'));
-      fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
+      const backdrop = screen.getByTestId('bottom-sheet-backdrop');
+      fireEvent.pointerDown(screen.getByTestId('content'));
+      fireEvent.pointerUp(backdrop);
+      fireEvent.click(backdrop);
       expect(onClose).not.toHaveBeenCalled();
     });
 
@@ -90,8 +92,23 @@ describe('BottomSheet', () => {
       render(<BottomSheet {...defaultProps} onClose={onClose} />);
 
       const backdrop = screen.getByTestId('bottom-sheet-backdrop');
-      fireEvent.mouseDown(backdrop);
+      fireEvent.pointerDown(backdrop);
+      fireEvent.pointerUp(backdrop);
       fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears press-started-inside state when closed so a later backdrop click still closes', () => {
+      // Press inside, close via another path (e.g. Escape) without a click, then reopen.
+      // The stale "started inside" flag must not block the next backdrop dismissal.
+      const onClose = jest.fn();
+      const { rerender } = render(<BottomSheet {...defaultProps} onClose={onClose} />);
+
+      fireEvent.pointerDown(screen.getByTestId('content'));
+      rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen={false} />);
+      rerender(<BottomSheet {...defaultProps} onClose={onClose} isOpen />);
+
+      fireEvent.click(screen.getByTestId('bottom-sheet-backdrop'));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Problem

In the Edit Fixture modal (and every modal built on `BottomSheet`), selecting text in a field — e.g. the **Fixture Name** input — and releasing the mouse button outside the modal closed it. The modal should only close via **Cancel**, **Update Fixture**, **Delete**, the **X** button, or **Escape**.

## Root cause

`BottomSheet.tsx` dismissed the modal on the **`click`** event, guarded only by `e.target === e.currentTarget`.

The browser dispatches a `click` to the **nearest common ancestor of the press and release targets**. A press that starts inside a field and releases on the backdrop has the backdrop as that common ancestor, so `click` fired directly on the backdrop with `e.target === e.currentTarget` and triggered `onClose()`. The inner `onClick={e => e.stopPropagation()}` never ran, because the click was dispatched on the backdrop, not bubbled up from the content.

## Fix

An `onPointerDown` handler on each backdrop (desktop + mobile) records whether the press began on a modal child rather than the backdrop. `handleBackdropClick` then dismisses only when the press **started on the backdrop**. Text-selection drags that start inside the modal no longer close it. Pointer events keep this behavior consistent across mouse, touch, and pen.

The press-origin ref is reset when the modal closes, so a press-inside that's dismissed via Escape (no click) can't leave stale state that blocks the next backdrop click after reopening.

Because the fix lives in the shared `BottomSheet` component, it benefits **every** modal in the app.

## Tests

- Repro test: press inside → release/click on backdrop → must not close (failed before the fix, passes after).
- Normal backdrop press-and-release still dismisses.
- Regression test for the close/reopen stale-state path.
- Full suite: 125 suites / 2771 tests pass; `npm run lint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)